### PR TITLE
Add flag to specify listen-address

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var (
 	liveUrl                 string
 	liveMeasurements        stringArgs
 	disableLiveMeasurements stringArgs
+	listenAddress string
 )
 
 type (
@@ -45,6 +46,7 @@ func init() {
 	flag.StringVar(&liveUrl, "live-url", "", "Websocket url for live measurements")
 	flag.Var(&liveMeasurements, "live", "Id of home to expect having live measurements")
 	flag.Var(&disableLiveMeasurements, "disable-live", "Id of home to disable live measurements")
+	flag.StringVar(&listenAddress, "listen-address", ":8080", "Address to listen on for HTTP requests (defaults to :8080)")
 	flag.Parse()
 }
 
@@ -138,6 +140,6 @@ func main() {
 		fmt.Fprintln(w, "Tibber prometheus exporter")
 	})
 	http.Handle("/metrics", promhttp.Handler())
-	err = http.ListenAndServe(":8080", nil)
+	err = http.ListenAndServe(listenAddress, nil)
 	exit(fmt.Sprintf("Error: %v", err))
 }


### PR DESCRIPTION
This pull requests adds an additional command line option `--listen-address`.

- This is useful, if e.g. `8080` (a more or less common port to use) is used by other applications, or if the port can't be used due to firewall restrictions
- Allows binding to other IP addresses instead of `::` and `*`
- The default remains at `:8080`, behavior without this flag is not changed