### PR TITLE
Add LastMeterConsumption and LastMeterProduction Metrics

### DIFF
--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -251,6 +251,12 @@ func (h *Home) SubscribeMeasurements(ctx context.Context, hc *http.Client, wsUrl
 					h.TimestampedValues.PowerFactor.Timestamp = m.LiveMeasurement.Timestamp
 					h.TimestampedValues.PowerFactor.Value = *m.LiveMeasurement.PowerFactor
 				}
+				if m.LiveMeasurement.LastMeterConsumption >= h.Measurements.LiveMeasurement.LastMeterConsumption {
+					h.Measurements.LiveMeasurement.LastMeterConsumption = m.LiveMeasurement.LastMeterConsumption
+				}
+				if m.LiveMeasurement.LastMeterProduction >= h.Measurements.LiveMeasurement.LastMeterProduction {
+					h.Measurements.LiveMeasurement.LastMeterProduction = m.LiveMeasurement.LastMeterProduction
+				}
 				h.Measurements.LiveMeasurement.Timestamp = m.LiveMeasurement.Timestamp
 			}
 			return err

--- a/internal/tibber/tibber.go
+++ b/internal/tibber/tibber.go
@@ -129,6 +129,8 @@ type Prices struct {
 type LiveMeasurement struct {
 	Timestamp               time.Time
 	Power                   float64
+	LastMeterConsumption    float64
+	LastMeterProduction     float64
 	MinPower                float64
 	MaxPower                float64
 	AveragePower            float64


### PR DESCRIPTION
While trying out some things with my deployment of this exporter and grafana I had some issues with data I tried to extract from the meter reading over longer periods. Investigating into this I found metrics in the API that expose the last Readings of the Production and Consumption Register of the Meter and implemented this into my local deployment of the exporter. Maybe this is worth to merge as I think its a helpful metric to collect.
I never really worked with the prometheus libraries and the Tibber API so please excuse me if the implementation is somewhat dirty or has errors. On my local deployment this change seems to work pretty well so far.