### PR TITLE
Add LastMeter values as metrics

### DIFF
--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -174,9 +174,11 @@ func (h *Home) SubscribeMeasurements(ctx context.Context, hc *http.Client, wsUrl
 				h.Measurements.LiveMeasurement.MinPower = m.LiveMeasurement.MinPower
 				h.Measurements.LiveMeasurement.MaxPower = m.LiveMeasurement.MaxPower
 				h.Measurements.LiveMeasurement.AveragePower = m.LiveMeasurement.AveragePower
+				h.Measurements.LiveMeasurement.LastMeterConsumption = m.LiveMeasurement.LastMeterConsumption
 				h.Measurements.LiveMeasurement.PowerProduction = m.LiveMeasurement.PowerProduction
 				h.Measurements.LiveMeasurement.MinPowerProduction = m.LiveMeasurement.MinPowerProduction
 				h.Measurements.LiveMeasurement.MaxPowerProduction = m.LiveMeasurement.MaxPowerProduction
+				h.Measurements.LiveMeasurement.LastMeterProduction = m.LiveMeasurement.LastMeterProduction
 				// Each hour tibber seems to adjust readings (to official hourly reading?) and the accumulated values could be a bit lower that the previous.
 				// This causes problems for prometheus counters, so skip those values.
 				if m.LiveMeasurement.AccumulatedConsumption >= h.Measurements.LiveMeasurement.AccumulatedConsumption ||

--- a/internal/tibber/tibber.go
+++ b/internal/tibber/tibber.go
@@ -132,6 +132,7 @@ type LiveMeasurement struct {
 	MinPower                float64
 	MaxPower                float64
 	AveragePower            float64
+	LastMeterConsumption    float64
 	AccumulatedConsumption  float64
 	AccumulatedCost         float64
 	CurrentL1               *float64
@@ -148,6 +149,7 @@ type LiveMeasurement struct {
 	PowerProductionReactive *float64
 	MinPowerProduction      float64
 	MaxPowerProduction      float64
+	LastMeterProduction     float64
 	PowerFactor             *float64
 }
 


### PR DESCRIPTION
According to https://developer.tibber.com/docs/reference#livemeasurement and also in own test, the Tibber API also provides the last meter active import/export register states in kilowatt-hours.

As those values are quite nice to track, I added them as exported metrics too.

Was a bit unsure about the naming. Happy to adjust those.